### PR TITLE
Fix typo on example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if (kIsWeb) result = 'hello Web';
 String result = deviceSelector(
       mobile: 'hello Mobile',
       desktop: 'hello Desktop',
-      web: 'hello Web'
+      web: 'hello Web',
 );
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,17 +43,19 @@ class MyApp extends StatelessWidget {
       Scaffold.of(context).showSnackBar(SnackBar(content: Text(message)));
 
   _selector() => selector(
-      android: 'hello Android',
-      ios: 'hello iOS',
-      fuchsia: 'hello Fuchsia',
-      linux: 'hello Linux',
-      mac: 'hello MacOS',
-      windows: 'hello Windows');
+        android: 'hello Android',
+        ios: 'hello iOS',
+        fuchsia: 'hello Fuchsia',
+        linux: 'hello Linux',
+        mac: 'hello MacOS',
+        windows: 'hello Windows',
+      );
 
   _deviceSelector() => deviceSelector(
-      mobile: 'hello Mobile',
-      desktop: 'hello Desktop',
-      web: 'hello Web');
+        mobile: 'hello Mobile',
+        desktop: 'hello Desktop',
+        web: 'hello Web',
+      );
 
   _functionParameter() => selector(
         android: (a, b) => a + b,


### PR DESCRIPTION
### Missing comma at example code
```dart
_selector() => selector(
        android: 'hello Android',
        ios: 'hello iOS',
        fuchsia: 'hello Fuchsia',
        linux: 'hello Linux',
        mac: 'hello MacOS',
        windows: 'hello Windows', // <---
      );
```
```dart
String result = deviceSelector(
  mobile: 'hello Mobile',
  desktop: 'hello Desktop',
  web: 'hello Web',   // <---
);
```
