### PR TITLE
Update README.md and example to explain generic type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# selector
+- [Selector](#selector)
+  - [Basic selector](#basic-selector)
+  - [Device selector](#device-selector)
+  - [OrElse selector](#orelse-selector)
+  - [Query](#query)
+# Selector
 
-Platform Selector
+Multi type support Platform Selector
 
 ## Basic selector
 - with `if`

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,7 @@ class MyApp extends StatelessWidget {
   _showSnackBar(BuildContext context, String message) =>
       Scaffold.of(context).showSnackBar(SnackBar(content: Text(message)));
 
-  _selector() => selector(
+  _selector() => selector<String>(
         android: 'hello Android',
         ios: 'hello iOS',
         fuchsia: 'hello Fuchsia',
@@ -51,13 +51,13 @@ class MyApp extends StatelessWidget {
         windows: 'hello Windows',
       );
 
-  _deviceSelector() => deviceSelector(
+  _deviceSelector() => deviceSelector<String>(
         mobile: 'hello Mobile',
         desktop: 'hello Desktop',
         web: 'hello Web',
       );
 
-  _functionParameter() => selector(
+  _functionParameter() => selector<Function(num, num)>(
         android: (a, b) => a + b,
         ios: (a, b) => a * b,
         windows: (a, b) => a / b,
@@ -66,7 +66,7 @@ class MyApp extends StatelessWidget {
         fuchsia: (a, b) => a - b,
       )(1, 2);
 
-  _androidOrElse() => androidOrElse('android-admob-id', 'ios-admob-id');
+  _androidOrElse() => androidOrElse<String>('android-admob-id', 'ios-admob-id');
 
-  _iosOrElse() => iosOrElse('ios-admob-id', 'android-admob-id');
+  _iosOrElse() => iosOrElse<String>('ios-admob-id', 'android-admob-id');
 }


### PR DESCRIPTION
### Generic type 을 지원한다는 것을 명시하기 위한 예제 업데이트
Example에 있는 selector 들에 <String\>,  <Function(num, num)> 을 추가했습니다.

### README.md
+ Table of contents 추가했습니다.
+ 이름에 Multi type support 를 붙였습니다 `Multi type support Platform Selector`